### PR TITLE
Rename Audio Emitter `autoPlay` property to `playing`

### DIFF
--- a/extensions/2.0/OMI_audio_emitter/README.md
+++ b/extensions/2.0/OMI_audio_emitter/README.md
@@ -159,7 +159,7 @@ Whether or not to loop the specified audio clip when finished.
 
 #### `playing`
 
-Whether or not the specified audio clip is playing.
+Whether or not the specified audio clip is playing. Saving this property to `true` will set the audio clip to play on load (autoplay).
 
 #### `source`
 

--- a/extensions/2.0/OMI_audio_emitter/README.md
+++ b/extensions/2.0/OMI_audio_emitter/README.md
@@ -159,7 +159,7 @@ Whether or not to loop the specified audio clip when finished.
 
 #### `playing`
 
-Whether or not the specified audio clip is playing. Saving this property `true` will set the audio clip to play on load (autoplay).
+Whether or not the specified audio clip is playing. Setting this property `true` will set the audio clip to play on load (autoplay).
 
 #### `source`
 

--- a/extensions/2.0/OMI_audio_emitter/README.md
+++ b/extensions/2.0/OMI_audio_emitter/README.md
@@ -159,7 +159,7 @@ Whether or not to loop the specified audio clip when finished.
 
 #### `playing`
 
-Whether or not the specified audio clip is playing. Saving this property to `true` will set the audio clip to play on load (autoplay).
+Whether or not the specified audio clip is playing. Saving this property `true` will set the audio clip to play on load (autoplay).
 
 #### `source`
 

--- a/extensions/2.0/OMI_audio_emitter/README.md
+++ b/extensions/2.0/OMI_audio_emitter/README.md
@@ -41,7 +41,7 @@ Audio emitter objects may be added to 3D nodes for positional audio or to the sc
           "type": "global",
           "gain": 1,
           "loop": true,
-          "autoPlay": true,
+          "playing": true,
           "source": 0
         },
         {
@@ -49,7 +49,7 @@ Audio emitter objects may be added to 3D nodes for positional audio or to the sc
           "type": "positional",
           "gain": 0.8,
           "loop": false,
-          "autoPlay": false,
+          "playing": false,
           "source": 1,
           "coneInnerAngle": 6.283185307179586,
           "coneOuterAngle": 6.283185307179586,
@@ -157,9 +157,9 @@ Unitless multiplier against original source volume for determining emitter loudn
 
 Whether or not to loop the specified audio clip when finished.
 
-#### `autoPlay`
+#### `playing`
 
-Whether or not to play the specified audio clip when this scene is loaded.
+Whether or not the specified audio clip is playing.
 
 #### `source`
 

--- a/extensions/2.0/OMI_audio_emitter/schema/audioEmitter.schema.json
+++ b/extensions/2.0/OMI_audio_emitter/schema/audioEmitter.schema.json
@@ -34,7 +34,7 @@
         "default": false
       },
       "playing": {
-        "description": "Whether or not the specified audio clip is playing. Saving this property to true will set the audio clip to play on load (autoplay).",
+        "description": "Whether or not the specified audio clip is playing. Saving this property true will set the audio clip to play on load (autoplay).",
         "type": "boolean",
         "default": false
       },

--- a/extensions/2.0/OMI_audio_emitter/schema/audioEmitter.schema.json
+++ b/extensions/2.0/OMI_audio_emitter/schema/audioEmitter.schema.json
@@ -34,7 +34,7 @@
         "default": false
       },
       "playing": {
-        "description": "Whether or not the specified audio clip is playing. Saving this property true will set the audio clip to play on load (autoplay).",
+        "description": "Whether or not the specified audio clip is playing. Setting this property true will set the audio clip to play on load (autoplay).",
         "type": "boolean",
         "default": false
       },

--- a/extensions/2.0/OMI_audio_emitter/schema/audioEmitter.schema.json
+++ b/extensions/2.0/OMI_audio_emitter/schema/audioEmitter.schema.json
@@ -33,8 +33,8 @@
         "type": "boolean",
         "default": false
       },
-      "autoPlay": {
-        "description": "Whether or not to play the specified audio clip when this scene is loaded.",
+      "playing": {
+        "description": "Whether or not the specified audio clip is playing. Saving this property to true will set the audio clip to play on load (autoplay).",
         "type": "boolean",
         "default": false
       },


### PR DESCRIPTION
This PR renames the autoPlay property to `playing` as discussed in https://github.com/omigroup/gltf-extensions/pull/1