### PR TITLE
Stage 5 Proposal: Khronos Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The extension has been ratified. It has multiple metaverse implementations, a gl
 
 ### Stage 5
 
-The extension has been submitted and merged as an OMI vendor extension or submitted and ratified as a KHR or EXT extension within the [Khronos 3D Formats Working Group](https://github.com/KhronosGroup/glTF).
+The extension has been submitted and merged as an OMI vendor extension. Alternately, if the extension is intended to be used outside the scope of OMI, it can be submitted and ratified as a KHR or EXT extension. The extension must be published to the [Khronos 3D Formats Working Group](https://github.com/KhronosGroup/glTF) repository to enter stage 5.
 
 #### Requirements
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We aim to create an ecosystem of specifications and tooling for accessible creat
 
 ## OMI glTF Working Group Process
 
-OMI uses 4 stages to represent the maturity of an extension:
+OMI uses 5 stages to represent the maturity of an extension:
 
 ### Stage 1
 
@@ -67,6 +67,15 @@ The extension has been ratified. It has multiple metaverse implementations, a gl
 - [ ] Previous requirements from Stage 3
 - [ ] The extension has passed a consensus vote for ratification.
 
+### Stage 5
+
+The extension has been submitted and merged as an OMI vendor extension or submitted and ratified as a KHR or EXT extension within the [Khronos 3D Formats Working Group](https://github.com/KhronosGroup/glTF).
+
+#### Requirements
+
+- [ ] Previous requirements from Stage 4
+- [ ] Listing on the [Khronos glTF repository](https://github.com/KhronosGroup/glTF/tree/main/extensions) proving the extension has been approved or ratified.
+
 
 ## OMI glTF Vendor Extensions
 
@@ -78,6 +87,8 @@ The extension has been ratified. It has multiple metaverse implementations, a gl
 ### Stage 3
 
 ### Stage 4
+
+### Stage 5
 
 ### Extension Support Table
 


### PR DESCRIPTION
I'd like to propose adding a 5th stage to our working group's process, submission to the Khronos 3D Formats Working Group. This stage would signal to others that we are aiming for wider adoption of our extensions within the glTF community and show that we are working with the Khronos Group to try to unify rather than fragment the ecosystem.

During @fire and my conversation with the glTF Working Group, they expressed fears about our work fragmenting the ecosystem. We responded saying that our intent is to eventually publish all relevant extensions to the Khronos Group. This small change would codify that and ensure we have a good working relationship with them.