### PR TITLE
Adds Three Object Viewer WordPress plugin to known implementations

### DIFF
--- a/extensions/2.0/OMI_audio_emitter/README.md
+++ b/extensions/2.0/OMI_audio_emitter/README.md
@@ -273,6 +273,7 @@ Radians are used for rotations matching glTF2.
 ## Known Implementations
 
 * Third Room - https://github.com/thirdroom/thirdroom
+* Three Object Viewer (WordPess Plugin) - https://wordpress.org/plugins/three-object-viewer/
 
 ## Resources
 

--- a/extensions/2.0/OMI_audio_emitter/README.md
+++ b/extensions/2.0/OMI_audio_emitter/README.md
@@ -273,7 +273,7 @@ Radians are used for rotations matching glTF2.
 ## Known Implementations
 
 * Third Room - https://github.com/thirdroom/thirdroom
-* Three Object Viewer (WordPess Plugin) - https://wordpress.org/plugins/three-object-viewer/
+* Three Object Viewer (WordPress Plugin) - https://wordpress.org/plugins/three-object-viewer/
 
 ## Resources
 


### PR DESCRIPTION
Woohoo! The three object viewer with support for three-omi and the audio emitter is live and already being used by WordPress developers! 

https://wordpress.org/plugins/three-object-viewer/

I've gone ahead and added it in now in the known implementations. I think this qualifies OMI Audio Emitter for stage 2! 🎉 