### PR TITLE
Adjusts to KHR_audio PR recommendations to split audio out

### DIFF
--- a/extensions/2.0/KHR_audio/README.md
+++ b/extensions/2.0/KHR_audio/README.md
@@ -29,33 +29,12 @@ Audio emitter objects may be added to 3D nodes for positional audio or to the sc
 {
   "extensions": {
     "KHR_audio": {
-      "sources": [
-        {
-          "name": "environment",
-          "uri": "./environment.mp3"
-        },
-        {
-          "name": "quack",
-          "mimeType": "audio/mpeg",
-          "bufferView": 5
-        }
-      ],
       "emitters": [
         {
-          "name": "environment emitter",
-          "type": "global",
-          "gain": 1.0,
-          "loop": true,
-          "playing": true,
-          "source": 0
-        },
-        {
-          "name": "duck emitter",
+          "name": "Positional Emitter",
           "type": "positional",
           "gain": 0.8,
-          "loop": false,
-          "playing": false,
-          "source": 1,
+          "inputs": [0, 1],
           "positional": {
             "coneInnerAngle": 6.283185307179586,
             "coneOuterAngle": 6.283185307179586,
@@ -65,6 +44,29 @@ Audio emitter objects may be added to 3D nodes for positional audio or to the sc
             "refDistance": 1.0,
             "rolloffFactor": 0.8
           }
+        }
+      ],
+      "sources": [
+        {
+          "name": "Clip 1",
+          "gain": 0.6,
+          "playing": true,
+          "loop": true,
+          "audio": 0
+        },
+        {
+          "name": "Clip 2",
+          "gain": 0.6,
+          "playing": true,
+          "loop": true,
+          "audio": 1
+        }
+      ],
+      "audio": [
+        {
+          "uri": "audio1.mp3",
+          "bufferView": 0,
+          "mimeType": "audio/mpeg"
         }
       ]
     }

--- a/extensions/2.0/KHR_audio/README.md
+++ b/extensions/2.0/KHR_audio/README.md
@@ -34,7 +34,7 @@ Audio emitter objects may be added to 3D nodes for positional audio or to the sc
           "name": "Positional Emitter",
           "type": "positional",
           "gain": 0.8,
-          "inputs": [0, 1],
+          "sources": [0, 1],
           "positional": {
             "coneInnerAngle": 6.283185307179586,
             "coneOuterAngle": 6.283185307179586,
@@ -50,14 +50,14 @@ Audio emitter objects may be added to 3D nodes for positional audio or to the sc
         {
           "name": "Clip 1",
           "gain": 0.6,
-          "playing": true,
+          "autoPlay": true,
           "loop": true,
           "audio": 0
         },
         {
           "name": "Clip 2",
           "gain": 0.6,
-          "playing": true,
+          "autoPlay": true,
           "loop": true,
           "audio": 1
         }
@@ -65,6 +65,8 @@ Audio emitter objects may be added to 3D nodes for positional audio or to the sc
       "audio": [
         {
           "uri": "audio1.mp3",
+        },
+        {
           "bufferView": 0,
           "mimeType": "audio/mpeg"
         }

--- a/extensions/2.0/KHR_audio/schema/emitter.schema.json
+++ b/extensions/2.0/KHR_audio/schema/emitter.schema.json
@@ -28,13 +28,13 @@
         "minimum": 0.0,
         "default": 1.0
       },
-      "inputs": {
+      "sources": {
         "description": "An array of audio sources used by the audio emitter.",
         "type": "array",
         "allOf": [
-              {
-                  "$ref": "glTFid.schema.json"
-              }
+          {
+              "$ref": "glTFid.schema.json"
+          }
         ]
       },
       "positional": {

--- a/extensions/2.0/KHR_audio/schema/emitter.schema.json
+++ b/extensions/2.0/KHR_audio/schema/emitter.schema.json
@@ -28,22 +28,13 @@
         "minimum": 0.0,
         "default": 1.0
       },
-      "loop": {
-        "description": "Whether or not to loop the specified audio clip when finished.",
-        "type": "boolean",
-        "default": false
-      },
-      "playing": {
-        "description": "Whether or not the specified audio clip is playing. Setting this property true will set the audio clip to play on load (autoplay).",
-        "type": "boolean",
-        "default": false
-      },
-      "source": {
-        "description": "The id of the audio source referenced by this audio emitter.",
+      "inputs": {
+        "description": "An array of audio sources used by the audio emitter.",
+        "type": "array",
         "allOf": [
-            {
-                "$ref": "glTFid.schema.json"
-            }
+              {
+                  "$ref": "glTFid.schema.json"
+              }
         ]
       },
       "positional": {

--- a/extensions/2.0/KHR_audio/schema/glTF.KHR_audio.schema.json
+++ b/extensions/2.0/KHR_audio/schema/glTF.KHR_audio.schema.json
@@ -11,6 +11,30 @@
               "type": "object",
               "$ref": "source.schema.json"
           },
+          "playing": {
+            "description": "Whether or not the specified audio clip is playing. Setting this property true will set the audio clip to play on load (autoplay).",
+            "type": "boolean",
+            "default": false
+          },
+          "gain": {
+            "description": "Unitless multiplier against original source volume for determining emitter loudness.",
+            "type": "number",
+            "minimum": 0.0,
+            "default": 1.0
+          },
+          "loop": {
+            "description": "Whether or not to loop the specified audio clip when finished.",
+            "type": "boolean",
+            "default": false
+          },
+          "audio": {
+            "description": "The id of the audio file assigned to this clip.",
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ]
+          },
           "minItems": 1
       },
       "emitters": {
@@ -22,11 +46,21 @@
         },
         "minItems": 1
     },
+    "audio": {
+        "description": "An array of audio that can be referenced by nodes.",
+        "type": "array",
+        "items": {
+            "type": "object",
+            "$ref": "source.schema.json"
+        },
+        "minItems": 1
+    },
       "extensions": { },
       "extras": { }
   },
   "required": [
       "sources",
-      "emitters"
+      "emitters",
+      "audio"
   ]
 }

--- a/extensions/2.0/KHR_audio/schema/glTF.KHR_audio.schema.json
+++ b/extensions/2.0/KHR_audio/schema/glTF.KHR_audio.schema.json
@@ -11,7 +11,7 @@
               "type": "object",
               "$ref": "source.schema.json"
           },
-          "playing": {
+          "autoPlay": {
             "description": "Whether or not the specified audio clip is playing. Setting this property true will set the audio clip to play on load (autoplay).",
             "type": "boolean",
             "default": false


### PR DESCRIPTION
This PR adjusts the schema structure to account for feedback provided in KHR_Audio proposal: 

https://github.com/KhronosGroup/glTF/pull/2137#issuecomment-1093239689

```
{
  "emitters": [
    {
      "name": "Positional Emitter",
      "type": "positional",
      "gain": 0.8,
      "inputs": [0, 1],
      "positional": {
        "coneInnerAngle": 6.283185307179586,
        "coneOuterAngle": 6.283185307179586,
        "coneOuterGain": 0.0,
        "distanceModel": "inverse",
        "maxDistance": 10.0,
        "refDistance": 1.0,
        "rolloffFactor": 0.8
      }
    }
  ],
  "sources": [
    {
      "name": "Clip 1",
      "gain": 0.6,
      "playing": true,
      "loop": true,
      "audio": 0
    },
    {
      "name": "Clip 2",
      "gain": 0.6,
      "playing": true,
      "loop": true,
      "audio": 1
    }
  ],
  "audio": [
    {
      "uri": "audio1.mp3"
    },
    {
      "bufferView": 0,
      "mimeType": "audio/mpeg"
    }
  ]
}
```