### PR TITLE
Clarify OMI_link <-> OMI_collider relationship

### DIFF
--- a/extensions/2.0/OMI_link/README.md
+++ b/extensions/2.0/OMI_link/README.md
@@ -22,7 +22,7 @@ This extension specification currently depends on the draft OMI_collider extensi
 
 This extension allows for objects to add world traversal behavior in the form of links. This specification does not contain any definitions in how the link data is used and it is up to the client builder to decide how the link is activated.
 
-Currently this spec depends on the OMI_collider spec. The OMI_collider extension should be attached to the same node as an OMI_link. The client may decide to use the collider for activating the link behavior on click and/or on collision. If OMI_collider is not defined on the node, clients should implement a default behavior for triggering the link.
+Currently this spec depends on the OMI_collider spec. The OMI_collider extension must be attached to the same node as an OMI_link. The client may decide to use the collider for activating the link behavior on click and/or on collision. If OMI_collider is not defined on the node the link the behavior is undefined and can be ignored.
 
 Clients may choose to have application-specific behaviors for URIs otherwise the default platform / browser URI handler should be used. Applications should perform any necessary URI security checks and may decide to present a dialog to inform the user of how the URI is handled.
 

--- a/extensions/2.0/OMI_link/README.md
+++ b/extensions/2.0/OMI_link/README.md
@@ -16,7 +16,7 @@ Open Metaverse Interoperability Group Stage 1 Proposal
 
 Written against the glTF 2.0 spec.
 
-OMI_collider extension
+This extension specification currently depends on the draft OMI_collider extension.
 
 ## Overview
 

--- a/extensions/2.0/OMI_link/README.md
+++ b/extensions/2.0/OMI_link/README.md
@@ -16,11 +16,15 @@ Open Metaverse Interoperability Group Stage 1 Proposal
 
 Written against the glTF 2.0 spec.
 
+OMI_collider extension
+
 ## Overview
 
 This extension allows for objects to add world traversal behavior in the form of links. This specification does not contain any definitions in how the link data is used and it is up to the client builder to decide how the link is activated.
 
-A collider attached to the same node as an OMI_link object can be assumed to be collidable or clickable for activating the traversal behavior.
+Currently this spec depends on the OMI_collider spec. The OMI_collider extension should be attached to the same node as an OMI_link. The collider can be assumed to be collidable or clickable for activating the traversal behavior.
+
+Clients may choose to have application-specific behaviors for URIs otherwise the default platform / browser URI handler should be used. Applications should perform any necessary URI security checks and may decide to present a dialog to inform the user of how the URI is handled.
 
 ### Example:
 

--- a/extensions/2.0/OMI_link/README.md
+++ b/extensions/2.0/OMI_link/README.md
@@ -22,7 +22,7 @@ This extension specification currently depends on the draft OMI_collider extensi
 
 This extension allows for objects to add world traversal behavior in the form of links. This specification does not contain any definitions in how the link data is used and it is up to the client builder to decide how the link is activated.
 
-Currently this spec depends on the OMI_collider spec. The OMI_collider extension should be attached to the same node as an OMI_link. The collider can be assumed to be collidable or clickable for activating the traversal behavior.
+Currently this spec depends on the OMI_collider spec. The OMI_collider extension should be attached to the same node as an OMI_link. The client may decide to use the collider for activating the link behavior on click and/or on collision. If OMI_collider is not defined on the node, clients should implement a default behavior for triggering the link.
 
 Clients may choose to have application-specific behaviors for URIs otherwise the default platform / browser URI handler should be used. Applications should perform any necessary URI security checks and may decide to present a dialog to inform the user of how the URI is handled.
 


### PR DESCRIPTION
Clarifies the language around how OMI_collider should be used within OMI_link and how the URIs should be handled.