### PR TITLE
Allow extensions and extras in all schemas

### DIFF
--- a/extensions/2.0/OMI_collider/schema/collider.schema.json
+++ b/extensions/2.0/OMI_collider/schema/collider.schema.json
@@ -22,7 +22,9 @@
             "type": "boolean",
             "description": "When true this collider will not be solid to physics bodies in the scene, and instead the shape will act as a trigger detection area.",
             "default": false
-        }
+        },
+        "extensions": { },
+        "extras": { }
     },
     "oneOf": [
         {

--- a/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.schema.json
+++ b/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.schema.json
@@ -37,6 +37,8 @@
             "type": "array",
             "description": "The inertia tensor 3x3 symmetric matrix of the body in kilogram meter squared.",
             "default": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-        }
+        },
+        "extensions": { },
+        "extras": { }
     }
 }

--- a/extensions/2.0/OMI_physics_joint/schema/glTF.OMI_physics_joint.schema.json
+++ b/extensions/2.0/OMI_physics_joint/schema/glTF.OMI_physics_joint.schema.json
@@ -19,6 +19,8 @@
                 "$ref": "joint_constraint.schema.json"
             },
             "minItems": 1
-        }
+        },
+        "extensions": { },
+        "extras": { }
     }
 }

--- a/extensions/2.0/OMI_physics_joint/schema/joint_constraint.schema.json
+++ b/extensions/2.0/OMI_physics_joint/schema/joint_constraint.schema.json
@@ -35,6 +35,8 @@
             "type": "number",
             "description": "When beyond the limits, the damping of the springing back motion.",
             "default": 1.0
-        }
+        },
+        "extensions": { },
+        "extras": { }
     }
 }

--- a/extensions/2.0/OMI_physics_joint/schema/node.OMI_physics_joint.schema.json
+++ b/extensions/2.0/OMI_physics_joint/schema/node.OMI_physics_joint.schema.json
@@ -29,6 +29,8 @@
             "description": "The id of the second node.",
             "type": "number",
             "$ref": "glTFid.schema.json"
-        }
+        },
+        "extensions": { },
+        "extras": { }
     }
 }

--- a/extensions/2.0/OMI_seat/schema/node.OMI_seat.schema.json
+++ b/extensions/2.0/OMI_seat/schema/node.OMI_seat.schema.json
@@ -24,6 +24,8 @@
             "type": "number",
             "description": "The angle between the spine and back-knee line in radians.",
             "default": 1.57079632679489662
-        }
+        },
+        "extensions": { },
+        "extras": { }
     }
 }

--- a/extensions/2.0/OMI_spawn_point/schema/spawn_point.schema.json
+++ b/extensions/2.0/OMI_spawn_point/schema/spawn_point.schema.json
@@ -18,6 +18,8 @@
 			"type": "string",
 			"description": "The group that this spawn point belongs to, if any.",
 			"maxLength": 128
-		}
+		},
+		"extensions": { },
+		"extras": { }
 	}
 }


### PR DESCRIPTION
This was a minor technical omission. All of the official schemas in the Khronos repo have these, so we should too.