### PR TITLE
Allow shapes to be directly on bodies or indirect children/descendants

### DIFF
--- a/extensions/2.0/OMI_physics_body/README.md
+++ b/extensions/2.0/OMI_physics_body/README.md
@@ -19,9 +19,11 @@ Depends on the `OMI_physics_shape` spec to be useful.
 
 This extension allows for specifying the type of physics body in glTF scenes.
 
-Physics bodies are defined with a string enum for the type. Nodes with physics shapes defined using the `OMI_physics_shape` spec should be added as direct children of physics bodies. In order to be associated with a `OMI_physics_body` glTF node, `OMI_physics_shape` glTF nodes must be direct children, not indirect children.
+Physics bodies are defined with a string enum for the type. Nodes with physics shapes defined using the `OMI_physics_shape` spec should be added as children of a `OMI_physics_body` glTF node.
 
-Each glTF node with `OMI_physics_shape` may be associated with zero or one `OMI_physics_body` glTF node as its direct parent. Each glTF node with `OMI_physics_body` should have one or many `OMI_physics_shape` glTF node direct children (zero is valid but not recommended, since physics bodies will not collide with anything if they have zero physics shape children).
+Each glTF node with `OMI_physics_shape` may be associated with zero or one `OMI_physics_body` glTF node as its ancestor. Each glTF node with `OMI_physics_body` should have one or many `OMI_physics_shape` glTF node descendants (zero is valid but not recommended, since physics bodies without collision shapes on them will not collide with anything). If a glTF node with `OMI_physics_shape` does not have a body, it should be a static solid object that does not move.
+
+Nodes with `OMI_physics_shape` are recommended to be direct child nodes of physics bodies they apply to, since this results in a very clear and portable document structure, and allows colliders to be transformed relative to the parent body via glTF node transforms. However, `OMI_physics_shape` may also be placed on the same glTF node as the physics body to accomodate very simple use cases, and may be placed on indirect descendants to allow for more complex objects with colliders on separate levels in the node hierarchy. A glTF node with `OMI_physics_shape` may only apply to one body, which is the `OMI_physics_body` on the same glTF node, or the nearest ancestor with `OMI_physics_body`.
 
 ### Example:
 

--- a/extensions/2.0/OMI_physics_body/examples/complex/indirect_children.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/indirect_children.gltf
@@ -1,0 +1,90 @@
+{
+	"asset": {
+		"version": "2.0"
+	},
+	"extensions": {
+		"OMI_physics_shape": {
+			"shapes": [
+				{
+					"type": "box",
+					"box": {
+						"size": [1, 1, 1]
+					}
+				}
+			]
+		}
+	},
+	"extensionsUsed": ["OMI_physics_shape", "OMI_physics_body"],
+	"nodes": [
+		{
+			"children": [1, 3, 5, 8, 11, 12],
+			"name": "IndirectColliders"
+		},
+		{
+			"children": [2],
+			"extensions": { "OMI_physics_body": { "type": "kinematic" } },
+			"name": "KinematicDirect",
+			"translation": [0, 0, 0]
+		},
+		{
+			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"name": "BoxShapeKinematicDirect"
+		},
+		{
+			"children": [4],
+			"extensions": { "OMI_physics_body": { "type": "trigger" } },
+			"name": "TriggerDirect",
+			"translation": [0, 0, -2]
+		},
+		{
+			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"name": "BoxShapeTriggerDirect"
+		},
+		{
+			"children": [6],
+			"extensions": { "OMI_physics_body": { "type": "kinematic" } },
+			"name": "KinematicIndirect",
+			"translation": [-2, 0, 0]
+		},
+		{
+			"children": [7],
+			"name": "IntermediaryNodeKinematic"
+		},
+		{
+			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"name": "BoxShapeKinematicIndirect"
+		},
+		{
+			"children": [9],
+			"extensions": { "OMI_physics_body": { "type": "trigger" } },
+			"name": "TriggerIndirect",
+			"translation": [-2, 0, -2]
+		},
+		{
+			"children": [10],
+			"name": "IntermediaryNodeTrigger"
+		},
+		{
+			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"name": "BoxShapeTriggerIndirect"
+		},
+		{
+			"extensions": {
+				"OMI_physics_body": { "type": "kinematic" },
+				"OMI_physics_shape": { "shape": 0 }
+			},
+			"name": "KinematicSameNode",
+			"translation": [2, 0, 0]
+		},
+		{
+			"extensions": {
+				"OMI_physics_body": { "type": "trigger" },
+				"OMI_physics_shape": { "shape": 0 }
+			},
+			"name": "TriggerSameNode",
+			"translation": [2, 0, -2]
+		}
+	],
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
+}


### PR DESCRIPTION
This is based on some ongoing discussion on converging the physics specs https://github.com/KhronosGroup/glTF/pull/2258

I am still skeptical of the portability of having indirect children, but Eoin very strongly desires this feature, so I think it would make sense to allow it and just recommend direct children for those desiring a simple document structure. Conceptually speaking, there is no reason this can't be allowed, the only objections are implementation difficulty.

Existing OMI assets do not need to be updated, they are automatically compliant, this is a superset.

I also added a test file that tests every possible edge case of the relative placement and types of OMI_physics_shape and OMI_physics_body in the node hierarchy, so an implementation can test all of the edge cases at once.