### PR TITLE
Restructure OMI physics to be much more like MSFT physics

### DIFF
--- a/extensions/2.0/OMI_link/README.md
+++ b/extensions/2.0/OMI_link/README.md
@@ -46,7 +46,7 @@ Clients may choose to have application-specific behaviors for URIs otherwise the
                     "uri": "https://omigroup.org/worlds/meetup"
                 },
                 "OMI_physics_body": {
-                    "type": "trigger"
+                    "trigger": {}
                 }
             }
         }

--- a/extensions/2.0/OMI_physics_body/README.collider.md
+++ b/extensions/2.0/OMI_physics_body/README.collider.md
@@ -1,0 +1,17 @@
+# OMI_physics_body Collider Property
+
+If a node has the `"collider"` property defined, it is a solid collider node that objects can collide with.
+
+## Collider Properties
+
+|           | Type      | Description                                           | Default value |
+| --------- | --------- | ----------------------------------------------------- | ------------- |
+| **shape** | `integer` | The index of the shape to use as the collision shape. | -1            |
+
+### Shape
+
+The `"shape"` property is an integer index that references a shape in the document-level shapes array as defined by the `OMI_physics_shape` extension. If not specified or -1, this node has no collider shape, but may be the parent of other nodes that do have collider shapes, and can combine those nodes into one collider (this may be a body or compound collider depending on the engine).
+
+## JSON Schema
+
+See [schema/node.OMI_physics_body.collider.schema.json](schema/node.OMI_physics_body.collider.schema.json) for the collider properties JSON schema.

--- a/extensions/2.0/OMI_physics_body/README.md
+++ b/extensions/2.0/OMI_physics_body/README.md
@@ -17,13 +17,11 @@ Depends on the `OMI_physics_shape` spec to be useful.
 
 ## Overview
 
-This extension allows for specifying the type of physics body in glTF scenes.
+This extension allows for specifying physics bodies in glTF scenes.
 
-Physics bodies are defined with a string enum for the type. Nodes with physics shapes defined using the `OMI_physics_shape` spec should be added as children of a `OMI_physics_body` glTF node.
+Nodes with the `OMI_physics_body` extension may define motion, collider, and trigger properties.
 
-Each glTF node with `OMI_physics_shape` may be associated with zero or one `OMI_physics_body` glTF node as its ancestor. Each glTF node with `OMI_physics_body` should have one or many `OMI_physics_shape` glTF node descendants (zero is valid but not recommended, since physics bodies without collision shapes on them will not collide with anything). If a glTF node with `OMI_physics_shape` does not have a body, it should be a static solid object that does not move.
-
-Nodes with `OMI_physics_shape` are recommended to be direct child nodes of physics bodies they apply to, since this results in a very clear and portable document structure, and allows colliders to be transformed relative to the parent body via glTF node transforms. However, `OMI_physics_shape` may also be placed on the same glTF node as the physics body to accomodate very simple use cases, and may be placed on indirect descendants to allow for more complex objects with colliders on separate levels in the node hierarchy. A glTF node with `OMI_physics_shape` may only apply to one body, which is the `OMI_physics_body` on the same glTF node, or the nearest ancestor with `OMI_physics_body`.
+If a node with a collider shape does not have a motion property, , it should be a static solid object that does not move.
 
 ### Example:
 
@@ -52,31 +50,25 @@ This example defines a static body node which has a single box collider as a chi
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "dynamic"
+                    },
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
-            "name": "StaticBox"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
-                }
-            },
-            "name": "StaticShape"
+            "name": "DynamicBox"
         }
     ],
     "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+    "scenes": [{ "nodes": [0] }]
 }
 ```
+
+The above example shows dynamic motion and collision shape specified on one node. A nearly identical example using 2 nodes can be found in [examples/basic/dynamic_box.gltf](examples/basic/dynamic_box.gltf).
 
 More example assets can be found in the [examples/](examples/) folder. All of these examples use both `OMI_physics_shape` and `OMI_physics_body`.
 
@@ -86,81 +78,46 @@ This extension consists of a new `OMI_physics_body` data structure which can be 
 
 The extension must also be added to the glTF's `extensionsUsed` array and because it is optional, it does not need to be added to the `extensionsRequired` array.
 
-The extension is intended to be used together with `OMI_physics_shape`. Physics bodies without collision shapes on them are valid but will not collide with anything.
+The extension is intended to be used together with `OMI_physics_shape`, which defines the shapes used by the `"shape"` properties inside of the `"collider"` and `"trigger"` sub-JSON properties.
 
 ### Property Summary
 
-|                     | Type        | Description                                                      | Default value        |
-| ------------------- | ----------- | ---------------------------------------------------------------- | -------------------- |
-| **type**            | `string`    | The type of the physics body as a string.                        | Required, no default |
-| **mass**            | `number`    | The mass of the physics body in kilograms.                       | 1.0                  |
-| **linearVelocity**  | `number[3]` | The initial linear velocity of the body in meters per second.    | [0.0, 0.0, 0.0]      |
-| **angularVelocity** | `number[3]` | The initial angular velocity of the body in radians per second.  | [0.0, 0.0, 0.0]      |
-| **centerOfMass**    | `number[3]` | The center of mass offset from the origin in meters.             | [0.0, 0.0, 0.0]      |
-| **inertiaTensor**   | `number[9]` | The inertia tensor 3x3 matrix in kilogram meter squared (kg⋅m²). | [0.0, ..., 0.0]      |
+|              | Type | Description                                                  | Default value |
+| ------------ | ---- | ------------------------------------------------------------ | ------------- |
+| **motion**   | JSON | If present, this node has its motion controlled by physics.  | `null`        |
+| **collider** | JSON | If present, this node is solid and can be collided with.     | `null`        |
+| **trigger**  | JSON | If present, this node is non-solid and can act as a trigger. | `null`        |
 
-### Physics Body Types
+Each of these properties are recommended to be defined on separate nodes. This results in a very clear, simple, and portable document structure, and ensures that each behavior has its own transform. However, they may also be all defined on the same node. Implementations must support all of these cases in order to be compliant.
 
-The `"type"` property is a lowercase string that defines what type of physics body this is. Different types of physics bodies have different interactions with physics systems and other bodies within a scene.
+#### Motion
 
-Here is a table listing the mapping between the `OMI_physics_body` type and the equivalent types in major game engines.
+If a node has the `"motion"` property defined, its transform is driven by the physics engine.
 
-| Body Type | Unity                 | Godot 3       | Godot 4          | Unreal                                 |
-| --------- | --------------------- | ------------- | ---------------- | -------------------------------------- |
-| Static    | Collider              | StaticBody    | StaticBody3D     | WorldStatic, Simulate Physics = false  |
-| Kinematic | Rigidbody.isKinematic | KinematicBody | AnimatableBody3D | WorldDynamic, Simulate Physics = false |
-| Dynamic   | Rigidbody             | RigidBody     | RigidBody3D      | PhysicsBody, Simulate Physics = true   |
-| Trigger   | Collider.isTrigger    | Area          | Area3D           | Generate Overlap Events = true         |
+The list of motion properties and their details can be found in the [README.motion.md](README.motion.md) file.
 
-#### Static
+#### Collider
 
-Static bodies can be collided with, but do not have simulated movement. They are usually used for level geometry.
+If a node has the `"collider"` property defined, it is a solid collider node that objects can collide with.
 
-#### Kinematic
-
-Kinematic bodies can be collided with, and can be moved using scripts or animations. They can be used for moving platforms.
-
-#### Dynamic
-
-Dynamic bodies are bodies simulated with [rigid body dynamics](https://en.wikipedia.org/wiki/Rigid_body_dynamics). They collide with other bodies, and move around on their own in the physics simulation. They are affected by gravity. They can be used for props that move around in the world.
+The list of collider properties and their details can be found in the [README.collider.md](README.collider.md) file.
 
 #### Trigger
 
-Trigger bodies do not collide with other objects, but can generate events when another physics body "enters" them. For example, a "goal" area which triggers whenever a ball gets thrown into it. Trigger bodies can be added as children of other bodies to attach a trigger volume to another body.
+If a node has the `"trigger"` property defined, it is a non-solid trigger that can detect when objects enter it.
 
-### Mass
-
-The `"mass"` property is a number that defines how much mass this physics body has in kilograms. Not all body types can make use of mass, such as triggers or non-moving bodies, in which case the mass can be ignored. If not specified, the default value is 1 kilogram.
-
-### Linear Velocity
-
-The `"linearVelocity"` property is an array of three numbers that defines how much linear velocity this physics body starts with in meters per second. Not all body types can make use of linear velocity, such as non-moving bodies, in which case the linear velocity can be ignored. If not specified, the default value is zero.
-
-### Angular Velocity
-
-The `"angularVelocity"` property is an array of three numbers that defines how much angular velocity this physics body starts with in radians per second. Not all body types can make use of angular velocity, such as non-moving bodies, in which case the angular velocity can be ignored. If not specified, the default value is zero.
-
-### Center of Mass
-
-The `"centerOfMass"` property is an array of three numbers that defines the position offset in meters of the center of mass in the body's local space.
-
-This property is useful when converting assets with a center of mass, but when creating new assets it is recommended to leave the center of mass at the body's origin. Some physics engines support the center of mass being offset from the origin, but not all of them do. Implementations without support for a center of mass offset would have to adjust the node positions to make this work, which may be undesired.
-
-### Inertia Tensor
-
-The `"inertiaTensor"` property is an array of 9 numbers that defines the inertia tensor 3x3 matrix of the body in kilogram meter squared (kg⋅m²). We specify "tensor" in the name because this defines inertia in multiple directions and is different from linear momentum inertia. Only the "dynamic" body type can make use of inertia. If zero or not specified, the inertia should be automatically calculated by the physics engine.
-
-The inertia tensor matrix is a symmetric matrix. The inertia matrix represents the mass distribution of the body and determines how hard the body is to rotate. The values on the diagonal represent the inertia around the 3 principle axes (X, Y, Z), while the values not on the diagonal represent the 3 coupling values between the axes (XY, XZ, YZ). For more information, refer to the Wikipedia article.
-
-Some engines only support specifying the inertia around the principle axes as a Vector3. In those engines, when importing a glTF file and reading the inertia matrix, only the diagonal principle axis values should be used, and the non-diagonal coupling values should be discarded. Similarly, when exporting a glTF file while writing the inertia matrix, write the Vector3 values to the matrix diagonal principle axis values, and set the non-diagonal coupling values to zero.
+The list of trigger properties and their details can be found in the [README.trigger.md](README.trigger.md) file.
 
 ### JSON Schema
 
-See [schema/node.OMI_physics_body.schema.json](schema/node.OMI_physics_body.schema.json).
+See [node.OMI_physics_body.schema.json](schema/node.OMI_physics_body.schema.json) for the main node schema, and these for the sub-JSON property schemas:
+* Motion: [node.OMI_physics_body.motion.schema.json](schema/node.OMI_physics_body.motion.schema.json)
+* Collider: [node.OMI_physics_body.collider.schema.json](schema/node.OMI_physics_body.collider.schema.json)
+* Trigger: [node.OMI_physics_body.trigger.schema.json](schema/node.OMI_physics_body.trigger.schema.json)
 
 ## Known Implementations
 
-* Godot Engine: https://github.com/godotengine/godot/pull/69266
+* Godot Engine: https://github.com/godotengine/godot/pull/78967
 
 ## Resources:
 
@@ -169,4 +126,5 @@ See [schema/node.OMI_physics_body.schema.json](schema/node.OMI_physics_body.sche
 * Godot Physics Body: https://docs.godotengine.org/en/stable/classes/class_physicsbody.html
 * Godot Area: https://docs.godotengine.org/en/stable/classes/class_area.html
 * Godot RigidBody3D: https://docs.godotengine.org/en/latest/classes/class_rigidbody3d.html
-* Wikipedia Moment of Inertia and Inertia Tensor https://en.wikipedia.org/wiki/Moment_of_inertia#Inertia_tensor
+* Wikipedia Moment of Inertia: https://en.wikipedia.org/wiki/Moment_of_inertia
+* Wikipedia Rigid Body Dynamics: https://en.wikipedia.org/wiki/Rigid_body_dynamics

--- a/extensions/2.0/OMI_physics_body/README.motion.md
+++ b/extensions/2.0/OMI_physics_body/README.motion.md
@@ -1,0 +1,73 @@
+# OMI_physics_body Motion Property
+
+If a node has the `"motion"` property defined, its transform is driven by the physics engine.
+
+* Descendant nodes should move with that node. The physics engine should treat them as part of a single body.
+* If a descendant node has its own motion property, that node should be treated as an independent body during simulation. There is no implicit requirement that it follows its "parent" rigid body.
+* If a node's transform is animated by animations in the file, those animations should take priority over the physics simulation.
+
+## Motion Properties
+
+|                        | Type        | Description                                                          | Default value        |
+| ---------------------- | ----------- | -------------------------------------------------------------------- | -------------------- |
+| **type**               | `string`    | The type of the physics body as a string.                            | Required, no default |
+| **mass**               | `number`    | The mass of the physics body in kilograms.                           | 1.0                  |
+| **linearVelocity**     | `number[3]` | The initial linear velocity of the body in meters per second.        | [0.0, 0.0, 0.0]      |
+| **angularVelocity**    | `number[3]` | The initial angular velocity of the body in radians per second.      | [0.0, 0.0, 0.0]      |
+| **centerOfMass**       | `number[3]` | The center of mass offset from the origin in meters.                 | [0.0, 0.0, 0.0]      |
+| **inertiaDiagonal**    | `number[3]` | The inertia around principle axes in kilogram meter squared (kg⋅m²). | [0.0, 0.0, 0.0]      |
+| **inertiaOrientation** | `number[4]` | The inertia orientation as a Quaternion.                             | [0.0, 0.0, 0.0, 1.0] |
+
+### Motion Types
+
+The `"type"` property is a lowercase string that defines what type of physics body this is. Different types of physics bodies have different interactions with physics systems and other bodies within a scene.
+
+Here is a table listing the mapping between the `OMI_physics_body` type and the equivalent types in major game engines.
+
+| Body Type | Unity                 | Godot 3       | Godot 4          | Unreal                                 |
+| --------- | --------------------- | ------------- | ---------------- | -------------------------------------- |
+| Static    | Collider              | StaticBody    | StaticBody3D     | WorldStatic, Simulate Physics = false  |
+| Kinematic | Rigidbody.isKinematic | KinematicBody | AnimatableBody3D | WorldDynamic, Simulate Physics = false |
+| Dynamic   | Rigidbody             | RigidBody     | RigidBody3D      | PhysicsBody, Simulate Physics = true   |
+
+#### Static
+
+Static bodies can be collided with, but do not have simulated movement. They are usually used for level geometry. Specifying a static body is optional, as nodes with collider properties are assumed to be static without itself or a parent node having the motion property.
+
+#### Kinematic
+
+Kinematic bodies can be collided with, and can be moved using scripts or animations. They can be used for moving platforms.
+
+#### Dynamic
+
+Dynamic bodies are bodies simulated with [rigid body dynamics](https://en.wikipedia.org/wiki/Rigid_body_dynamics). They collide with other bodies, and move around on their own in the physics simulation. They are affected by gravity. They can be used for props that move around in the world.
+
+### Mass
+
+The `"mass"` property is a number that defines how much mass this physics body has in kilograms. Not all body types can make use of mass, such as triggers or non-moving bodies, in which case the mass can be ignored. If not specified, the default value is 1 kilogram.
+
+### Linear Velocity
+
+The `"linearVelocity"` property is an array of three numbers that defines how much linear velocity this physics body starts with in meters per second. Not all body types can make use of linear velocity, such as non-moving bodies, in which case the linear velocity can be ignored. If not specified, the default value is zero.
+
+### Angular Velocity
+
+The `"angularVelocity"` property is an array of three numbers that defines how much angular velocity this physics body starts with in radians per second. Not all body types can make use of angular velocity, such as non-moving bodies, in which case the angular velocity can be ignored. If not specified, the default value is zero.
+
+### Center of Mass
+
+The `"centerOfMass"` property is an array of three numbers that defines the position offset in meters of the center of mass in the body's local space. If not specified, the default value is zero.
+
+This property is useful when converting assets with a center of mass, but when creating new assets it is recommended to leave the center of mass at the body's origin. Some physics engines support the center of mass being offset from the origin, but not all of them do. Implementations without support for a center of mass offset would have to adjust the node positions to make this work, which may be undesired.
+
+### Inertia Diagonal
+
+The `"inertiaDiagonal"` property is an array of 3 numbers that defines the inertia around the principle axes of the body in kilogram meter squared (kg⋅m²). We specify "tensor" in the name because this defines inertia in multiple directions and is different from linear momentum inertia. Only the "dynamic" motion type can make use of inertia. If zero or not specified, the inertia should be automatically calculated by the physics engine.
+
+### Inertia Orientation
+
+The `"inertiaOrientation"` property is an array of 4 numbers that defines a Quaternion for orientation of the inertia's principle axes relative to the body's local space. If not specified or set to the default value of `[0.0, 0.0, 0.0, 1.0]`, no rotation is applied, the inertia's principle axes are aligned with the body's local space axes.
+
+## JSON Schema
+
+See [schema/node.OMI_physics_body.motion.schema.json](schema/node.OMI_physics_body.motion.schema.json) for the motion properties JSON schema.

--- a/extensions/2.0/OMI_physics_body/README.trigger.md
+++ b/extensions/2.0/OMI_physics_body/README.trigger.md
@@ -1,0 +1,19 @@
+# OMI_physics_body Trigger Property
+
+If a node has the `"trigger"` property defined, it has a non-solid trigger shape that can detect when objects enter it.
+
+Triggers are not solid and do not "collide" with other objects, but can generate events when another physics body "enters" them. For example, a "goal" area which triggers whenever a ball gets thrown into it.
+
+## Trigger Properties
+
+|           | Type      | Description                                         | Default value |
+| --------- | --------- | --------------------------------------------------- | ------------- |
+| **shape** | `integer` | The index of the shape to use as the trigger shape. | -1            |
+
+### Shape
+
+The `"shape"` property is an integer index that references a shape in the document-level shapes array as defined by the `OMI_physics_shape` extension. If not specified or -1, this node has no trigger shape, but may be the parent of other nodes that do have trigger shapes, and should combine those nodes into one trigger (this may be a body or compound trigger depending on the engine).
+
+## JSON Schema
+
+See [schema/node.OMI_physics_body.trigger.schema.json](schema/node.OMI_physics_body.trigger.schema.json) for the trigger properties JSON schema.

--- a/extensions/2.0/OMI_physics_body/examples/basic/dynamic_box.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/basic/dynamic_box.gltf
@@ -8,7 +8,7 @@
                 {
                     "type": "box",
                     "box": {
-                        "size": [1, 1, 1]
+                        "size": [1, 2, 3]
                     }
                 }
             ]
@@ -20,14 +20,25 @@
     ],
     "nodes": [
         {
+            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "trigger": {
+                    "motion": {
+                        "type": "dynamic"
+                    }
+                }
+            },
+            "name": "DynamicBox"
+        },
+        {
+            "extensions": {
+                "OMI_physics_body": {
+                    "collider": {
                         "shape": 0
                     }
                 }
             },
-            "name": "TriggerBox"
+            "name": "BoxShape"
         }
     ],
     "scene": 0,

--- a/extensions/2.0/OMI_physics_body/examples/complex/ball_pit.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/ball_pit.gltf
@@ -1352,7 +1352,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "Pit"
@@ -1362,8 +1364,10 @@
                 3
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "Floor"
@@ -1378,8 +1382,10 @@
                 5
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "WallEast",
@@ -1399,8 +1405,10 @@
                 7
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "WallWest",
@@ -1420,8 +1428,10 @@
                 9
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 2
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 2
+                    }
                 }
             },
             "name": "WallNorth",
@@ -1442,8 +1452,10 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "mass": 1,
-                    "type": "dynamic"
+                    "motion": {
+                        "mass": 1,
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball1",
@@ -1458,8 +1470,10 @@
                 12
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 3
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 3
+                    }
                 }
             },
             "name": "SphereShape1"
@@ -1475,8 +1489,10 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "mass": 1,
-                    "type": "dynamic"
+                    "motion": {
+                        "mass": 1,
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball2",
@@ -1491,8 +1507,10 @@
                 15
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 3
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 3
+                    }
                 }
             },
             "name": "SphereShape2"
@@ -1508,8 +1526,10 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "mass": 1,
-                    "type": "dynamic"
+                    "motion": {
+                        "mass": 1,
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball3",
@@ -1524,8 +1544,10 @@
                 18
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 3
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 3
+                    }
                 }
             },
             "name": "SphereShape3"
@@ -1541,8 +1563,10 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "mass": 1,
-                    "type": "dynamic"
+                    "motion": {
+                        "mass": 1,
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball4",
@@ -1557,8 +1581,10 @@
                 21
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 3
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 3
+                    }
                 }
             },
             "name": "SphereShape4"
@@ -1574,8 +1600,10 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "mass": 1,
-                    "type": "dynamic"
+                    "motion": {
+                        "mass": 1,
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball5",
@@ -1590,8 +1618,10 @@
                 24
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 3
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 3
+                    }
                 }
             },
             "name": "SphereShape5"
@@ -1619,11 +1649,5 @@
         }
     ],
     "scene": 0,
-    "scenes": [
-        {
-            "nodes": [
-                0
-            ]
-        }
-    ]
+    "scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_body/examples/complex/dynamic_with_velocity.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/dynamic_with_velocity.gltf
@@ -25,17 +25,21 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "angularVelocity": [4, 5, 6],
-                    "linearVelocity": [1, 2, 3],
-                    "type": "dynamic"
+                    "motion": {
+                        "angularVelocity": [4, 5, 6],
+                        "linearVelocity": [1, 2, 3],
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "DynamicWithVelocity"
         },
         {
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "SphereShape"

--- a/extensions/2.0/OMI_physics_body/examples/complex/indirect_children.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/indirect_children.gltf
@@ -22,27 +22,47 @@
 		},
 		{
 			"children": [2],
-			"extensions": { "OMI_physics_body": { "type": "kinematic" } },
+			"extensions": {
+				"OMI_physics_body": {
+					"motion": { "type": "kinematic" }
+				}
+			},
 			"name": "KinematicDirect",
 			"translation": [0, 0, 0]
 		},
 		{
-			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"extensions": {
+				"OMI_physics_body": {
+					"collider": { "shape": 0 }
+				}
+			},
 			"name": "BoxShapeKinematicDirect"
 		},
 		{
 			"children": [4],
-			"extensions": { "OMI_physics_body": { "type": "trigger" } },
+			"extensions": {
+				"OMI_physics_body": {
+					"trigger": {}
+				}
+			},
 			"name": "TriggerDirect",
 			"translation": [0, 0, -2]
 		},
 		{
-			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"extensions": {
+				"OMI_physics_body": {
+					"trigger": { "shape": 0 }
+				}
+			},
 			"name": "BoxShapeTriggerDirect"
 		},
 		{
 			"children": [6],
-			"extensions": { "OMI_physics_body": { "type": "kinematic" } },
+			"extensions": {
+				"OMI_physics_body": {
+					"motion": { "type": "kinematic" }
+				}
+			},
 			"name": "KinematicIndirect",
 			"translation": [-2, 0, 0]
 		},
@@ -51,12 +71,20 @@
 			"name": "IntermediaryNodeKinematic"
 		},
 		{
-			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"extensions": {
+				"OMI_physics_body": {
+					"collider": { "shape": 0 }
+				}
+			},
 			"name": "BoxShapeKinematicIndirect"
 		},
 		{
 			"children": [9],
-			"extensions": { "OMI_physics_body": { "type": "trigger" } },
+			"extensions": {
+				"OMI_physics_body": {
+					"trigger": {}
+				}
+			},
 			"name": "TriggerIndirect",
 			"translation": [-2, 0, -2]
 		},
@@ -65,21 +93,28 @@
 			"name": "IntermediaryNodeTrigger"
 		},
 		{
-			"extensions": { "OMI_physics_shape": { "shape": 0 } },
+			"extensions": {
+				"OMI_physics_body": {
+					"trigger": { "shape": 0 }
+				}
+			},
 			"name": "BoxShapeTriggerIndirect"
 		},
 		{
 			"extensions": {
-				"OMI_physics_body": { "type": "kinematic" },
-				"OMI_physics_shape": { "shape": 0 }
+				"OMI_physics_body": {
+					"motion": { "type": "kinematic" },
+					"collider": { "shape": 0 }
+				}
 			},
 			"name": "KinematicSameNode",
 			"translation": [2, 0, 0]
 		},
 		{
 			"extensions": {
-				"OMI_physics_body": { "type": "trigger" },
-				"OMI_physics_shape": { "shape": 0 }
+				"OMI_physics_body": {
+					"trigger": { "shape": 0 }
+				}
 			},
 			"name": "TriggerSameNode",
 			"translation": [2, 0, -2]

--- a/extensions/2.0/OMI_physics_body/examples/complex/static_body_motion.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/static_body_motion.gltf
@@ -8,7 +8,7 @@
                 {
                     "type": "box",
                     "box": {
-                        "size": [1, 1, 1]
+                        "size": [1, 2, 3]
                     }
                 }
             ]
@@ -20,14 +20,25 @@
     ],
     "nodes": [
         {
+            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "trigger": {
+                    "motion": {
+                        "type": "static"
+                    }
+                }
+            },
+            "name": "StaticBodyMotion"
+        },
+        {
+            "extensions": {
+                "OMI_physics_body": {
+                    "collider": {
                         "shape": 0
                     }
                 }
             },
-            "name": "TriggerBox"
+            "name": "BoxShape"
         }
     ],
     "scene": 0,

--- a/extensions/2.0/OMI_physics_body/examples/complex/static_compound_collider.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/static_compound_collider.gltf
@@ -8,7 +8,7 @@
                 {
                     "type": "box",
                     "box": {
-                        "size": [1, 1, 1]
+                        "size": [1, 2, 3]
                     }
                 }
             ]
@@ -23,24 +23,22 @@
             "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "collider": {}
                 }
             },
-            "name": "StaticBox"
+            "name": "StaticCompoundCollider"
         },
         {
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "BoxShape"
         }
     ],
     "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+    "scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_body/examples/complex/static_with_trigger.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/static_with_trigger.gltf
@@ -29,41 +29,34 @@
             "children": [1, 2],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "StaticBox"
         },
         {
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "StaticShape"
         },
         {
-            "children": [3],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "trigger"
-                }
-            },
-            "name": "TriggerBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                    "trigger": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "TriggerShape"
         }
     ],
     "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+    "scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_body/examples/complex/two_boxes.gltf
+++ b/extensions/2.0/OMI_physics_body/examples/complex/two_boxes.gltf
@@ -28,16 +28,20 @@
             "children": [2],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
-            "name": "StaticBox",
+            "name": "StaticBody",
             "translation": [-1, 0, 0]
         },
         {
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "StaticBoxShape"
@@ -46,25 +50,23 @@
             "children": [4],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "trigger"
+                    "trigger": {}
                 }
             },
-            "name": "TriggerBox",
+            "name": "TriggerBody",
             "translation": [1, 0, 0]
         },
         {
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "trigger": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "TriggerBoxShape"
         }
     ],
     "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+    "scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.collider.schema.json
+++ b/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.collider.schema.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "OMI_physics_body Collider Property",
+    "type": "object",
+    "allOf": [
+        {
+            "$ref": "glTFProperty.schema.json"
+        }
+    ],
+    "properties": {
+        "shape": {
+            "description": "The id of the shape referenced by this node.",
+            "allOf": [
+                {
+                    "$ref": "glTFid.schema.json"
+                }
+            ],
+            "default": -1
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.motion.schema.json
+++ b/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.motion.schema.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "title": "OMI_physics_body Motion Property",
+    "type": "object",
+    "required": [
+        "type"
+    ],
+    "properties": {
+        "type": {
+            "type": "string",
+            "description": "The motion type of this physics body as a string.",
+            "enum": [
+                "static",
+                "kinematic",
+                "dynamic"
+            ]
+        },
+        "mass": {
+            "type": "number",
+            "description": "The mass of this physics body in kilograms.",
+            "default": 1.0
+        },
+        "linearVelocity": {
+            "type": "array",
+            "description": "The initial linear velocity of the body in meters per second.",
+            "default": [0.0, 0.0, 0.0]
+        },
+        "angularVelocity": {
+            "type": "array",
+            "description": "The initial angular velocity of the body in radians per second.",
+            "default": [0.0, 0.0, 0.0]
+        },
+        "inertiaDiagonal": {
+            "type": "array",
+            "description": "The inertia around principle axes in kilogram meter squared. If zero or not specified, the inertia should be calculated automatically.",
+            "default": [0.0, 0.0, 0.0]
+        },
+        "inertiaOrientation": {
+            "type": "array",
+            "description": "The inertia orientation as a Quaternion. If not specified, the inertia is not rotated.",
+            "default": [0.0, 0.0, 0.0, 1.0]
+        },
+        "extensions": { },
+        "extras": { }
+    }
+}

--- a/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.schema.json
+++ b/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.schema.json
@@ -2,39 +2,21 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "title": "OMI_physics_body glTF Node Extension",
     "type": "object",
-    "required": [
-        "type"
-    ],
     "properties": {
-        "type": {
-            "type": "string",
-            "description": "The body type of this physics body as a string.",
-            "enum": [
-                "static",
-                "kinematic",
-                "dynamic",
-                "trigger"
-            ]
+        "motion": {
+            "type": "object",
+            "description": "If present, this node has its motion controlled by physics, specified by these motion parameters.",
+            "$ref": "glTF.OMI_physics_body.motion.schema.json"
         },
-        "mass": {
-            "type": "number",
-            "description": "The mass of this physics body in kilograms.",
-            "default": 1.0
+        "collider": {
+            "type": "object",
+            "description": "If present, this node is solid and can be collided with, specified by these collider parameters.",
+            "$ref": "glTF.OMI_physics_body.collider.schema.json"
         },
-        "linearVelocity": {
-            "type": "array",
-            "description": "The initial linear velocity of the body in meters per second.",
-            "default": [0.0, 0.0, 0.0]
-        },
-        "angularVelocity": {
-            "type": "array",
-            "description": "The initial angular velocity of the body in radians per second.",
-            "default": [0.0, 0.0, 0.0]
-        },
-        "inertiaTensor": {
-            "type": "array",
-            "description": "The inertia tensor 3x3 symmetric matrix of the body in kilogram meter squared.",
-            "default": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        "trigger": {
+            "type": "object",
+            "description": "If present, this node is non-solid and can act as a trigger, specified by these trigger parameters.",
+            "$ref": "glTF.OMI_physics_body.trigger.schema.json"
         },
         "extensions": { },
         "extras": { }

--- a/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.trigger.schema.json
+++ b/extensions/2.0/OMI_physics_body/schema/node.OMI_physics_body.trigger.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "OMI_physics_shape glTF Node Extension",
+    "title": "OMI_physics_body Trigger Property",
     "type": "object",
     "allOf": [
         {
@@ -14,12 +14,10 @@
                 {
                     "$ref": "glTFid.schema.json"
                 }
-            ]
+            ],
+            "default": -1
         },
         "extensions": { },
         "extras": { }
-    },
-    "required": [
-        "shape"
-    ]
+    }
 }

--- a/extensions/2.0/OMI_physics_joint/README.md
+++ b/extensions/2.0/OMI_physics_joint/README.md
@@ -62,7 +62,9 @@ This example defines 2 rigid bodies that are connected with a joint that constra
         {
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "BodyA",
@@ -72,7 +74,9 @@ This example defines 2 rigid bodies that are connected with a joint that constra
         {
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "BodyB",
@@ -178,7 +182,7 @@ In this chart, "fixed" means "constrained with lower and upper limits set to zer
 
 ### JSON Schema
 
-See [schema/joint_constraint.schema.json](schema/joint_constraint.schema.json), [schema/node.OMI_physics_joint.schema.json](schema/node.OMI_physics_joint.schema.json), and [schema/glTF.OMI_physics_joint.schema.json](schema/glTF.OMI_physics_joint.schema.json) for the schemas.
+See [joint_constraint.schema.json](schema/joint_constraint.schema.json), [node.OMI_physics_joint.schema.json](schema/node.OMI_physics_joint.schema.json), and [glTF.OMI_physics_joint.schema.json](schema/glTF.OMI_physics_joint.schema.json) for the schemas.
 
 ## Known Implementations
 

--- a/extensions/2.0/OMI_physics_joint/examples/hanging_rope.gltf
+++ b/extensions/2.0/OMI_physics_joint/examples/hanging_rope.gltf
@@ -652,7 +652,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "Ceiling",
@@ -667,8 +669,10 @@
                 3
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "CeilingShape"
@@ -701,7 +705,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentTop",
@@ -722,8 +728,10 @@
                 7
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeTop",
@@ -762,7 +770,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentMiddle",
@@ -783,8 +793,10 @@
                 11
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeMiddle",
@@ -823,7 +835,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentBottom",
@@ -838,8 +852,10 @@
                 15
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeBottom",

--- a/extensions/2.0/OMI_physics_joint/examples/pendulum_balls.gltf
+++ b/extensions/2.0/OMI_physics_joint/examples/pendulum_balls.gltf
@@ -1084,7 +1084,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "TopBody",
@@ -1099,8 +1101,10 @@
                 3
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "TopBodyShape"
@@ -1135,7 +1139,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball1",
@@ -1150,8 +1156,10 @@
                 7
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "BallShape1"
@@ -1196,7 +1204,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball2",
@@ -1217,8 +1227,10 @@
                 12
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "BallShape2"
@@ -1269,7 +1281,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball3",
@@ -1290,8 +1304,10 @@
                 17
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "BallShape22"

--- a/extensions/2.0/OMI_physics_joint/examples/rope_railing.gltf
+++ b/extensions/2.0/OMI_physics_joint/examples/rope_railing.gltf
@@ -1084,7 +1084,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "PoleLeft",
@@ -1099,8 +1101,10 @@
                 3
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "PoleShapeLeft"
@@ -1133,7 +1137,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentLeft",
@@ -1154,8 +1160,10 @@
                 7
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeLeft",
@@ -1194,7 +1202,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentLeftMiddle",
@@ -1215,8 +1225,10 @@
                 11
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeLeftMiddle",
@@ -1255,7 +1267,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentMiddle",
@@ -1270,8 +1284,10 @@
                 15
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeMiddle",
@@ -1310,7 +1326,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentRightMiddle",
@@ -1331,8 +1349,10 @@
                 19
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeRightMiddle",
@@ -1371,7 +1391,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "RopeSegmentRight",
@@ -1392,8 +1414,10 @@
                 23
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "RopeShapeRight",
@@ -1432,7 +1456,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "PoleRight",
@@ -1447,8 +1473,10 @@
                 27
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "PoleShapeRight"

--- a/extensions/2.0/OMI_physics_joint/examples/simple_joint.gltf
+++ b/extensions/2.0/OMI_physics_joint/examples/simple_joint.gltf
@@ -500,7 +500,9 @@
             "children": [4],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "BodyA",
@@ -511,7 +513,9 @@
             "children": [6],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "BodyB",
@@ -525,8 +529,10 @@
         {
             "children": [5],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "ShapeA",
@@ -540,8 +546,10 @@
         {
             "children": [7],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "ShapeB",
@@ -556,7 +564,9 @@
             "children": [9],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "FloorBody",
@@ -565,8 +575,10 @@
         {
             "children": [10],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "FloorShape"

--- a/extensions/2.0/OMI_physics_joint/examples/slider_ball.gltf
+++ b/extensions/2.0/OMI_physics_joint/examples/slider_ball.gltf
@@ -385,7 +385,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "SliderLine"
@@ -395,8 +397,10 @@
                 3
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "SliderLineShape"
@@ -432,17 +436,19 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "angularVelocity": [
-                        0.0174532998353243,
-                        0.0174532998353243,
-                        0.0174532998353243
-                    ],
-                    "linearVelocity": [
-                        1,
-                        0.00000000000208164995657567,
-                        0.00000000000208164995657567
-                    ],
-                    "type": "dynamic"
+                    "motion": {
+                        "angularVelocity": [
+                            0.0174532998353243,
+                            0.0174532998353243,
+                            0.0174532998353243
+                        ],
+                        "linearVelocity": [
+                            1,
+                            0.00000000000208164995657567,
+                            0.00000000000208164995657567
+                        ],
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball",
@@ -457,8 +463,10 @@
                 7
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "BallShape"

--- a/extensions/2.0/OMI_physics_joint/examples/swing_and_slide.gltf
+++ b/extensions/2.0/OMI_physics_joint/examples/swing_and_slide.gltf
@@ -519,7 +519,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "TopBody",
@@ -534,8 +536,10 @@
                 3
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "TopBodyShape"
@@ -571,7 +575,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "Ball",
@@ -592,8 +598,10 @@
                 7
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "BallShape"

--- a/extensions/2.0/OMI_physics_joint/examples/weld_joint.gltf
+++ b/extensions/2.0/OMI_physics_joint/examples/weld_joint.gltf
@@ -495,7 +495,9 @@
             "children": [2],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "BodyA",
@@ -505,8 +507,10 @@
         {
             "children": [3],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "ShapeA",
@@ -534,7 +538,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "dynamic"
+                    "motion": {
+                        "type": "dynamic"
+                    }
                 }
             },
             "name": "BodyB",
@@ -545,8 +551,10 @@
                 7
             ],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "ShapeB",
@@ -563,7 +571,9 @@
             ],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "motion": {
+                        "type": "static"
+                    }
                 }
             },
             "name": "FloorBody",
@@ -572,8 +582,10 @@
         {
             "children": [10],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 1
+                "OMI_physics_body": {
+                    "collider": {
+                        "shape": 1
+                    }
                 }
             },
             "name": "FloorShape"

--- a/extensions/2.0/OMI_physics_shape/README.md
+++ b/extensions/2.0/OMI_physics_shape/README.md
@@ -18,15 +18,15 @@ Does nothing on its own. Designed to be used together with the `OMI_physics_body
 
 ## Overview
 
-Physics shapes can be added to glTF nodes along with information about the "type" of shape it is representing.
+This extension allows specifying physics shapes to be used in glTF scenes.
 
-This extension allows specifying physics shapes to be used in glTF scenes. `OMI_physics_shape` can be added to glTF nodes, which references the document-level list of physics shapes. They are meant to be used by `OMI_physics_body`. Without a body or another extension using it, this extension does not mandate any particular behavior for the nodes aside from their geometric shape. The precise usage of these physics shape primitives SHOULD be specified by the extenions which utilize them. In general, these physics shapes are used to specify geometry which can be used for collision detection.
+All types of physics shapes defined in this extension are intended to be used for physics simulations and to be portable between many engines. Without another extension using it, this extension does not mandate any particular behavior for the shapes aside from their geometric properties. The precise usage of these physics shape primitives SHOULD be specified by the extenions which utilize them. In general, these physics shapes are used to specify geometry which can be used for collision detection.
 
-The `OMI_physics_body` extension specifes the behavior of attached shapes, including static, kinematic, rigid, and non-solid triggers. Implementations MUST also implement `OMI_physics_body` to determine the behavior of the shapes, or else the shapes do not have defined behavior. Even for a scene with physics shapes that do not move, the body extension contains crucial information about how the shape should be treated, notably whether the shape is solid or not (a trigger body's shapes are not solid).
+The `OMI_physics_shape` extension is intended to be used together with the `OMI_physics_body` extension, which allows attaching shapes to glTF nodes and specifying their behavior, including static, kinematic, dynamic, and non-solid triggers. The `OMI_physics_body` extension refers to a shape using an index of a shape in the `OMI_physics_shape` document-level shapes array.
 
 ### Example:
 
-This example defines a single box shape with a size of 1 meter in all dimensions as a child of a static body:
+This example defines a single box shape with a size of 1 meter in all dimensions:
 
 ```json
 {
@@ -46,33 +46,7 @@ This example defines a single box shape with a size of 1 meter in all dimensions
         }
     },
     "extensionsUsed": [
-        "OMI_physics_body",
         "OMI_physics_shape"
-    ],
-    "nodes": [
-        {
-            "children": [1],
-            "extensions": {
-                "OMI_physics_body": {
-                    "type": "static"
-                }
-            },
-            "name": "StaticBox"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
-                }
-            },
-            "name": "BoxShape"
-        }
-    ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
     ]
 }
 ```
@@ -131,11 +105,11 @@ Sphere shapes describe a uniform "ball" shape. They have a `radius` property whi
 
 #### Capsule
 
-Capsule shapes describe a "pill" shape. They have a `radius` and `height` property. The height is aligned with the node's local vertical axis. If you wish to align it along a different axis, rotate the glTF node. If the `radius` property is omitted, the default radius is `0.5`, and if the `height` property is omitted, the default height is `2.0`. The height describes the total height from bottom to top. The height of the capsule must be at least twice as much as the radius. The "mid-height" between the centers of each spherical cap end can be found with `height - radius * 2.0`.
+Capsule shapes describe a "pill" shape. They have a `radius` and `height` property. The height is aligned with the node's local vertical axis. If it's desired to align it along a different axis, rotate the glTF node. If the `radius` property is omitted, the default radius is `0.5`, and if the `height` property is omitted, the default height is `2.0`. The height describes the total height from bottom to top. The height of the capsule must be at least twice as much as the radius. The "mid-height" between the centers of each spherical cap end can be found with `height - radius * 2.0`.
 
 #### Cylinder
 
-Cylinder shapes describe a "tall circle" shape. They are similar in structure to capsules, they have a `radius` and `height` property. The height is aligned with the node's local vertical axis. If you wish to align it along a different axis, rotate the glTF node. If the `radius` property is omitted, the default radius is `0.5`, and if the `height` property is omitted, the default height is `2.0`.
+Cylinder shapes describe a "tall circle" shape. They are similar in structure to capsules, they have a `radius` and `height` property. The height is aligned with the node's local vertical axis. If it's desired to align it along a different axis, rotate the glTF node. If the `radius` property is omitted, the default radius is `0.5`, and if the `height` property is omitted, the default height is `2.0`.
 
 The use of cylinder is discouraged if another shape would work well in its place. Cylinders are harder to calculate than boxes, spheres, and capsules. Not all game engines support cylinder shapes. Engines that do not support cylinder shapes should use an approximation, such as a convex hull roughly shaped like a cylinder. Cylinders over twice as tall as they are wide can use another approximation: a convex hull combined with an embedded capsule (to allow for smooth rolling), by copying the cylinder's values into a new capsule shape.
 
@@ -151,15 +125,15 @@ When convex hulls are used, asset creators should try to limit the number of ver
 
 Trimesh shapes represent a concave triangle mesh. They are defined with a `mesh` property with an index of a mesh in the glTF `meshes` array. The glTF mesh in the array MUST be a `trimesh` to work, and should be made of only one glTF mesh primitive (one surface). Valid trimesh shapes must contain at least one triangle.
 
-Avoid using a trimesh shape for most objects, they are the slowest shapes to calculate and have several limitations. Most physics engines do not support moving trimesh shapes or calculating collisions between multiple trimesh shapes. Trimesh shapes will not work reliably with trigger bodies or with pushing objects out due to not having an "interior" space, they only have a surface. Trimesh shapes are typically used for complex level geometry (for example, things that you can go inside of). If your shape can be represented with a combination of simpler primitives, or a convex hull, or multiple convex hulls, prefer that instead.
+Avoid using a trimesh shape for most objects, they are the slowest shapes to calculate and have several limitations. Most physics engines do not support moving trimesh shapes or calculating collisions between multiple trimesh shapes. Trimesh shapes will not work reliably with trigger bodies or with pushing objects out due to not having an "interior" space, they only have a surface. Trimesh shapes are typically used for complex level geometry (for example, things that objects can go inside of). If a shape can be represented with a combination of simpler primitives, or a convex hull, or multiple convex hulls, prefer that instead.
 
 ### JSON Schema
 
-See [schema/glTF.OMI_physics_shape.shape.schema.json](schema/glTF.OMI_physics_shape.shape.schema.json) for the main shape schema, [schema/glTF.OMI_physics_shape.schema.json](schema/glTF.OMI_physics_shape.schema.json) for the document-level list of shapes, and [schema/node.OMI_physics_shape.schema.json](schema/node.OMI_physics_shape.schema.json) for the node-level shape.
+See [glTF.OMI_physics_shape.schema.json](schema/glTF.OMI_physics_shape.schema.json) for the document-level list of shapes, [glTF.OMI_physics_shape.shape.schema.json](schema/glTF.OMI_physics_shape.shape.schema.json) for the shape resource schema, and the `glTF.OMI_physics_shape.shape.*.schema.json` files for the individual shape types.
 
 ## Known Implementations
 
-* None
+* Godot Engine: https://github.com/godotengine/godot/pull/78967
 
 ## Resources:
 

--- a/extensions/2.0/OMI_physics_shape/examples/box_collider.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/box_collider.gltf
@@ -20,27 +20,16 @@
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
-                }
-            },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "BoxShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/capsule_collider.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/capsule_collider.gltf
@@ -21,27 +21,16 @@
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
-                }
-            },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "CapsuleShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/convex/convex_hull.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/convex/convex_hull.gltf
@@ -216,21 +216,15 @@
     ],
     "nodes": [
         {
-            "children": [1, 2],
+            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
-                }
-            },
-            "name": "ConvexHull"
+            "name": "ConvexHullShape"
         },
         {
             "extensions": {},
@@ -238,12 +232,6 @@
             "name": "ConvexMesh"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [
-                0
-            ]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/convex/convex_hull_only.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/convex/convex_hull_only.gltf
@@ -88,29 +88,16 @@
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
-                }
-            },
-            "name": "ConvexHull"
+            "name": "ConvexHullShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [
-                0
-            ]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/cylinder_collider.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/cylinder_collider.gltf
@@ -21,27 +21,16 @@
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
-                }
-            },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "CylinderShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/default_box.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/default_box.gltf
@@ -17,27 +17,16 @@
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
-                }
-            },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "DefaultBoxShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/sphere_collider.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/sphere_collider.gltf
@@ -20,27 +20,16 @@
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
-                }
-            },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "SphereShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [0]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/trimesh/concave_trimesh.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/trimesh/concave_trimesh.gltf
@@ -175,34 +175,22 @@
     ],
     "nodes": [
         {
-            "children": [1, 2],
+            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
-            "name": "StaticBody"
+            "name": "ConcaveTrimeshShape"
         },
         {
             "extensions": {},
             "mesh": 0,
             "name": "BoxMeshInstance"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
-                }
-            },
-            "name": "ConcaveTrimeshShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [
-                0
-            ]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/examples/trimesh/concave_trimesh_only.gltf
+++ b/extensions/2.0/OMI_physics_shape/examples/trimesh/concave_trimesh_only.gltf
@@ -88,29 +88,16 @@
     ],
     "nodes": [
         {
-            "children": [1],
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "static"
-                }
-            },
-            "name": "StaticBody"
-        },
-        {
-            "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                    "collider": {
+                        "shape": 0
+                    }
                 }
             },
             "name": "ConcaveTrimeshShape"
         }
     ],
-    "scene": 0,
-    "scenes": [
-        {
-            "nodes": [
-                0
-            ]
-        }
-    ]
+	"scene": 0,
+	"scenes": [{ "nodes": [0] }]
 }

--- a/extensions/2.0/OMI_physics_shape/schema/glTF.OMI_physics_shape.shape.schema.json
+++ b/extensions/2.0/OMI_physics_shape/schema/glTF.OMI_physics_shape.shape.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
-    "title": "OMI_physics_shape Shape",
+    "title": "OMI_physics_shape Shape Resource",
     "type": "object",
     "required": [
         "type"

--- a/extensions/2.0/OMI_seat/examples/recliner_chair_with_trigger.gltf
+++ b/extensions/2.0/OMI_seat/examples/recliner_chair_with_trigger.gltf
@@ -36,10 +36,10 @@
                 0,
                 2
             ],
-            "name": "ReclinerChairFullWithBody",
+            "name": "ReclinerChairFullWithTrigger",
             "extensions": {
                 "OMI_physics_body": {
-                    "type": "trigger"
+                    "trigger": {}
                 },
                 "OMI_seat": {
                     "back": [0, 0.33, -0.247],
@@ -53,8 +53,10 @@
             "name": "ReclinerChairShape",
             "translation": [0, 0.5, 0],
             "extensions": {
-                "OMI_physics_shape": {
-                    "shape": 0
+                "OMI_physics_body": {
+                    "trigger": {
+                        "shape": 0
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR modifies the structure of OMI physics to be more like [MSFT physics](https://github.com/eoineoineoin/glTF_Physics).

* There is now a `"motion"` property that describes motion (can be of type static, kinematic, or dynamic). If motion properties are set then this is node is a "body" node with its motion driven by the physics engine. This is what a node with OMI_physics_body was in the old version of OMI_physics_body.
* The OMI_physics_shape extension is no longer specified on a GLTF node. Instead, specify OMI_physics_body with `"collider"` and `"trigger"` properties, each having a shape reference to the document-level shape array.

Note: In the MSFT spec, the README is very long considering all of the features in it. In this PR I split the README up into multiple pieces. Note that the collider README is short for now but it will be longer after we add physics materials and collision filtering in the future. Note that there will be one more README file added in the future for joints.

Preview these changes: https://github.com/aaronfranke/gltf-extensions/tree/msft-style-restructure/extensions/2.0/OMI_physics_body

This Godot PR implements these changes (while keeping compatibility for the old OMI formats for OMI_physics_body and OMI_collider): https://github.com/godotengine/godot/pull/78967