### PR TITLE
Sync KHR_audio with the Khronos PR

### DIFF
--- a/extensions/2.0/KHR_audio/schema/emitter.schema.json
+++ b/extensions/2.0/KHR_audio/schema/emitter.schema.json
@@ -29,7 +29,7 @@
         "default": 1.0
       },
       "sources": {
-        "description": "An array of audio sources used by the audio emitter.",
+        "description": "An array of audio source indices used by the audio emitter. This array may be empty.",
         "type": "array",
         "allOf": [
           {

--- a/extensions/2.0/KHR_audio/schema/source.schema.json
+++ b/extensions/2.0/KHR_audio/schema/source.schema.json
@@ -6,23 +6,23 @@
   "allOf": [ { "$ref": "glTFProperty.schema.json" } ],
   "properties": {
     "autoPlay": {
-        "description": "Whether or not the specified audio clip is playing. Setting this property true will set the audio clip to play on load (autoplay).",
+        "description": "Whether or not to play the specified audio when the glTF is loaded.",
         "type": "boolean",
         "default": false
     },
     "gain": {
-        "description": "Unitless multiplier against original source volume for determining emitter loudness.",
+        "description": "Unitless multiplier against original audio file volume for determining audio source loudness.",
         "type": "number",
         "minimum": 0.0,
         "default": 1.0
     },
     "loop": {
-        "description": "Whether or not to loop the specified audio clip when finished.",
+        "description": "Whether or not to loop the specified audio when finished.",
         "type": "boolean",
         "default": false
     },
     "audio": {
-        "description": "The id of the audio file assigned to this clip.",
+        "description": "The index of the audio data assigned to this clip.",
         "allOf": [
             {
                 "$ref": "glTFid.schema.json"


### PR DESCRIPTION
I noticed the files in this repo were out-of-sync with the latest contents of [the PR to Khronos](https://github.com/KhronosGroup/glTF/pull/2137), so this PR syncs the changes there back to the omigroup/gltf-extensions repo. This is an exact copy, no changes vs the PR.