### PR TITLE
Define glTF Object Model properties for OMI extensions

### DIFF
--- a/extensions/2.0/KHR_audio_emitter/README.md
+++ b/extensions/2.0/KHR_audio_emitter/README.md
@@ -8,7 +8,7 @@
 - Michael Nisbet, Individual Contributor
 - humbletim, Individual Contributor
 - Norbert Nopper, UX3D [@UX3DGpuSoftware](https://twitter.com/UX3DGpuSoftware)
-- Aaron Franke, The Mirror Megaverse Inc.
+- Aaron Franke, Godot Engine.
 
 ## Status
 
@@ -356,6 +356,31 @@ The gain relative to cone properties is determined in a similar way as described
 ### Unit for Angles
 
 Radians are used for angles matching glTF2.
+
+### glTF Object Model
+
+The following JSON pointers are defined representing mutable properties defined by this extension, for use with the glTF Object Model including extensions such as `KHR_animation_pointer` and `KHR_interactivity`.
+
+| JSON Pointer                                                          | Object Model Type |
+| --------------------------------------------------------------------- | ----------------- |
+| `/extensions/KHR_audio_emitter/emitters/{}/gain`                      | `float`           |
+| `/extensions/KHR_audio_emitter/emitters/{}/positional/coneInnerAngle` | `float`           |
+| `/extensions/KHR_audio_emitter/emitters/{}/positional/coneOuterAngle` | `float`           |
+| `/extensions/KHR_audio_emitter/emitters/{}/positional/coneOuterGain`  | `float`           |
+| `/extensions/KHR_audio_emitter/emitters/{}/positional/maxDistance`    | `float`           |
+| `/extensions/KHR_audio_emitter/emitters/{}/positional/refDistance`    | `float`           |
+| `/extensions/KHR_audio_emitter/emitters/{}/positional/rolloffFactor`  | `float`           |
+| `/extensions/KHR_audio_emitter/sources/{}/autoPlay`                   | `bool`            |
+| `/extensions/KHR_audio_emitter/sources/{}/gain`                       | `float`           |
+| `/extensions/KHR_audio_emitter/sources/{}/loop`                       | `bool`            |
+
+Additionally, the following JSON pointers are defined for read-only properties:
+
+| JSON Pointer                                    | Object Model Type |
+| ----------------------------------------------- | ----------------- |
+| `/extensions/KHR_audio_emitter/emitters.length` | `int`             |
+| `/extensions/KHR_audio_emitter/sources.length`  | `int`             |
+| `/extensions/KHR_audio_emitter/audio.length`    | `int`             |
 
 ### JSON Schema
 

--- a/extensions/2.0/OMI_audio_ogg_vorbis/README.md
+++ b/extensions/2.0/OMI_audio_ogg_vorbis/README.md
@@ -115,6 +115,10 @@ If a glTF contains an audio source using Ogg Vorbis audio with no fallback audio
 
 If a glTF contains an audio source using Ogg Vorbis audio with no fallback audio data, and `KHR_audio_emitter` is not a required extension, then do not add `OMI_audio_ogg_vorbis` to `extensionsRequired`. Clients supporting `KHR_audio_emitter` but not `OMI_audio_ogg_vorbis` will consider the lack of `"audio"` in a `KHR_audio_emitter` source to be an error, and either will not be able to play audio from that source, or will not load the `KHR_audio_emitter` extension.
 
+### glTF Object Model
+
+This extension defines no properties that can be read or manipulated by the glTF Object Model.
+
 ### JSON Schema
 
 See [schema/glTF.KHR_audio_emitter.source.OMI_audio_ogg_vorbis.schema.json](schema/glTF.KHR_audio_emitter.source.OMI_audio_ogg_vorbis.schema.json) for the schema.

--- a/extensions/2.0/OMI_audio_opus/README.md
+++ b/extensions/2.0/OMI_audio_opus/README.md
@@ -121,6 +121,10 @@ If a glTF contains an audio source using Opus audio with no fallback audio data,
 
 If a glTF contains an audio source using Opus audio with no fallback audio data, and `KHR_audio_emitter` is not a required extension, then do not add `OMI_audio_opus` to `extensionsRequired`. Clients supporting `KHR_audio_emitter` but not `OMI_audio_opus` will consider the lack of `"audio"` in a `KHR_audio_emitter` source to be an error, and either will not be able to play audio from that source, or will not load the `KHR_audio_emitter` extension.
 
+### glTF Object Model
+
+This extension defines no properties that can be read or manipulated by the glTF Object Model.
+
 ### JSON Schema
 
 See [schema/glTF.KHR_audio_emitter.source.OMI_audio_opus.schema.json](schema/glTF.KHR_audio_emitter.source.OMI_audio_opus.schema.json) for the schema.

--- a/extensions/2.0/OMI_link/README.md
+++ b/extensions/2.0/OMI_link/README.md
@@ -75,6 +75,10 @@ vrchat://launch?id=wrld_hjdksahgklfshjfgjklsd
 
 Optional field that describes the destination of the uri. Implementations can show this title if it exists or fallback to showing the uri.
 
+### glTF Object Model
+
+This extension defines no properties that can be read or manipulated by the glTF Object Model.
+
 ### JSON Schema
 
 TODO

--- a/extensions/2.0/OMI_physics_body/README.collider.md
+++ b/extensions/2.0/OMI_physics_body/README.collider.md
@@ -69,6 +69,23 @@ When a pair of physics materials interact during a simulation step, the applied 
 - Else if either uses `"maximum"`: The largest of the two values should be used.
 - Else if either uses `"multiply"`: The two values should be multiplied with each other.
 
+## glTF Object Model
+
+The following JSON pointers are defined representing mutable physics material properties defined by this extension, for use with the glTF Object Model including extensions such as `KHR_animation_pointer` and `KHR_interactivity`. See also the list of motion properties in the [README.motion.md](README.motion.md) file.
+
+| JSON Pointer                                                       | Object Model Type |
+| ------------------------------------------------------------------ | ----------------- |
+| `/extensions/OMI_physics_body/physicsMaterials/{}/staticFriction`  | `float`           |
+| `/extensions/OMI_physics_body/physicsMaterials/{}/dynamicFriction` | `float`           |
+| `/extensions/OMI_physics_body/physicsMaterials/{}/restitution`     | `float`           |
+
+Additionally, the following JSON pointers are defined for read-only properties:
+
+| JSON Pointer                                           | Object Model Type |
+| ------------------------------------------------------ | ----------------- |
+| `/extensions/OMI_physics_body/collisionFilters.length` | `int`             |
+| `/extensions/OMI_physics_body/physicsMaterials.length` | `int`             |
+
 ## JSON Schema
 
 See [schema/node.OMI_physics_body.collider.schema.json](schema/node.OMI_physics_body.collider.schema.json) for the collider properties JSON schema.

--- a/extensions/2.0/OMI_physics_body/README.md
+++ b/extensions/2.0/OMI_physics_body/README.md
@@ -123,6 +123,12 @@ For more details on collision filters, see the [README.trigger.md](README.trigge
 
 For more details on physics materials, see the [README.collider.md](README.collider.md) file.
 
+### glTF Object Model
+
+See the [README.motion.md](README.motion.md) file for the JSON pointers defined for the motion properties.
+
+See the [README.collider.md](README.collider.md) file for the JSON pointers defined for the collider physics material properties.
+
 ### JSON Schema
 
 See [node.OMI_physics_body.schema.json](schema/node.OMI_physics_body.schema.json) for the main node schema, and these for the sub-JSON property schemas:

--- a/extensions/2.0/OMI_physics_body/README.motion.md
+++ b/extensions/2.0/OMI_physics_body/README.motion.md
@@ -73,6 +73,20 @@ The `"angularVelocity"` property is an array of three numbers that defines how m
 
 The `"gravityFactor"` property is a number that defines a multiplier applied to the acceleration due to gravity. Values other than 1.0 are not realistic, but may be useful for artistic effects. If not specified, the default value is 1.0.
 
+## glTF Object Model
+
+The following JSON pointers are defined representing mutable motion properties defined by this extension, for use with the glTF Object Model including extensions such as `KHR_animation_pointer` and `KHR_interactivity`. See also the list of physics material properties in the [README.collider.md](README.collider.md) file.
+
+| JSON Pointer                                                      | Object Model Type |
+| ----------------------------------------------------------------- | ----------------- |
+| `/nodes/{}/extensions/OMI_physics_body/motion/mass`               | `float`           |
+| `/nodes/{}/extensions/OMI_physics_body/motion/centerOfMass`       | `float3`          |
+| `/nodes/{}/extensions/OMI_physics_body/motion/inertiaDiagonal`    | `float3`          |
+| `/nodes/{}/extensions/OMI_physics_body/motion/inertiaOrientation` | `float4`          |
+| `/nodes/{}/extensions/OMI_physics_body/motion/linearVelocity`     | `float3`          |
+| `/nodes/{}/extensions/OMI_physics_body/motion/angularVelocity`    | `float3`          |
+| `/nodes/{}/extensions/OMI_physics_body/motion/gravityFactor`      | `float`           |
+
 ## JSON Schema
 
 See [schema/node.OMI_physics_body.motion.schema.json](schema/node.OMI_physics_body.motion.schema.json) for the motion properties JSON schema.

--- a/extensions/2.0/OMI_physics_gravity/README.md
+++ b/extensions/2.0/OMI_physics_gravity/README.md
@@ -243,6 +243,26 @@ The gravity types described above can be used in a variety of ways to create a w
 | Wedge        | Line gravity with 2 points where the line is defined at the corner edge of a trigger volume.           |
 | Cone         | Line gravity with 2 points, plus directional gravity pointing towards the large end of the cone.       |
 
+### glTF Object Model
+
+The following JSON pointers are defined representing mutable properties defined by this extension, for use with the glTF Object Model including extensions such as `KHR_animation_pointer` and `KHR_interactivity`.
+
+| JSON Pointer                                                     | Object Model Type |
+| ---------------------------------------------------------------- | ----------------- |
+| `/extensions/OMI_physics_gravity/gravity`                        | `float`           |
+| `/nodes/{}/extensions/OMI_physics_gravity/gravity`               | `float`           |
+| `/nodes/{}/extensions/OMI_physics_gravity/priority`              | `int`             |
+| `/nodes/{}/extensions/OMI_physics_gravity/replace`               | `bool`            |
+| `/nodes/{}/extensions/OMI_physics_gravity/stop`                  | `bool`            |
+| `/nodes/{}/extensions/OMI_physics_gravity/directional/direction` | `float3`          |
+| `/nodes/{}/extensions/OMI_physics_gravity/disc/radius`           | `float`           |
+| `/nodes/{}/extensions/OMI_physics_gravity/disc/unitDistance`     | `float`           |
+| `/nodes/{}/extensions/OMI_physics_gravity/line/points`           | `float[]`         |
+| `/nodes/{}/extensions/OMI_physics_gravity/line/unitDistance`     | `float`           |
+| `/nodes/{}/extensions/OMI_physics_gravity/point/unitDistance`    | `float`           |
+| `/nodes/{}/extensions/OMI_physics_gravity/torus/radius`          | `float`           |
+| `/nodes/{}/extensions/OMI_physics_gravity/torus/unitDistance`    | `float`           |
+
 ### JSON Schema
 
 See [schema/glTF.OMI_physics_gravity.schema.json](schema/glTF.OMI_physics_gravity.schema.json) for document-level gravity, [schema/node.OMI_physics_gravity.schema.json](schema/node.OMI_physics_gravity.schema.json) for node-level gravity, and the `schema/node.OMI_physics_gravity.*.schema.json` files for the sub-JSON schemas for gravity types.

--- a/extensions/2.0/OMI_physics_shape/README.md
+++ b/extensions/2.0/OMI_physics_shape/README.md
@@ -2,9 +2,9 @@
 
 ## Contributors
 
-* Aaron Franke, The Mirror Megaverse Inc.
-* Robert Long, The Matrix.org Foundation
-* Mauve Signweaver, Mauve Software Inc.
+- Aaron Franke, Godot Engine.
+- Robert Long, The Matrix.org Foundation
+- Mauve Signweaver, Mauve Software Inc.
 
 ## Status
 
@@ -127,19 +127,38 @@ Trimesh shapes represent a concave triangle mesh. They are defined with a `mesh`
 
 Avoid using a trimesh shape for most objects, they are the slowest shapes to calculate and have several limitations. Most physics engines do not support moving trimesh shapes or calculating collisions between multiple trimesh shapes. Trimesh shapes will not work reliably with trigger bodies or with pushing objects out due to not having an "interior" space, they only have a surface. Trimesh shapes are typically used for complex level geometry (for example, things that objects can go inside of). If a shape can be represented with a combination of simpler primitives, or a convex hull, or multiple convex hulls, prefer that instead.
 
+### glTF Object Model
+
+The following JSON pointers are defined representing mutable properties defined by this extension, for use with the glTF Object Model including extensions such as `KHR_animation_pointer` and `KHR_interactivity`.
+
+| JSON Pointer                                              | Object Model Type |
+| --------------------------------------------------------- | ----------------- |
+| `/extensions/OMI_physics_shape/shapes/{}/box/size`        | `float3`          |
+| `/extensions/OMI_physics_shape/shapes/{}/sphere/radius`   | `float`           |
+| `/extensions/OMI_physics_shape/shapes/{}/capsule/radius`  | `float`           |
+| `/extensions/OMI_physics_shape/shapes/{}/capsule/height`  | `float`           |
+| `/extensions/OMI_physics_shape/shapes/{}/cylinder/radius` | `float`           |
+| `/extensions/OMI_physics_shape/shapes/{}/cylinder/height` | `float`           |
+
+Additionally, the following JSON pointers are defined for read-only properties:
+
+| JSON Pointer                                  | Object Model Type |
+| --------------------------------------------- | ----------------- |
+| `/extensions/OMI_physics_shape/shapes.length` | `int`             |
+
 ### JSON Schema
 
 See [glTF.OMI_physics_shape.schema.json](schema/glTF.OMI_physics_shape.schema.json) for the document-level list of shapes, [glTF.OMI_physics_shape.shape.schema.json](schema/glTF.OMI_physics_shape.shape.schema.json) for the shape resource schema, and the `glTF.OMI_physics_shape.shape.*.schema.json` files for the individual shape types.
 
 ## Known Implementations
 
-* Godot Engine: https://github.com/godotengine/godot/pull/78967
+- Godot Engine: https://github.com/godotengine/godot/pull/78967
 
 ## Resources:
 
-* Godot Shapes: https://docs.godotengine.org/en/latest/classes/class_shape3d.html
-* Unity Colliders: https://docs.unity3d.com/Manual/CollidersOverview.html
-* Unreal Engine Collision Shapes: https://docs.unrealengine.com/4.27/en-US/API/Runtime/PhysicsCore/FCollisionShape/
-* Unreal Engine Mesh Collisions: https://docs.unrealengine.com/4.27/en-US/WorkingWithContent/Types/StaticMeshes/HowTo/SettingCollision/
-* Blender Collisions: https://docs.blender.org/manual/en/latest/physics/rigid_body/properties/collisions.html
-* Mozilla Hubs ammo-shape: https://github.com/MozillaReality/hubs-blender-exporter/blob/bb28096159e1049b6b80da00b1ae1534a6ca0855/default-config.json#L608
+- Godot Shapes: https://docs.godotengine.org/en/latest/classes/class_shape3d.html
+- Unity Colliders: https://docs.unity3d.com/Manual/CollidersOverview.html
+- Unreal Engine Collision Shapes: https://docs.unrealengine.com/4.27/en-US/API/Runtime/PhysicsCore/FCollisionShape/
+- Unreal Engine Mesh Collisions: https://docs.unrealengine.com/4.27/en-US/WorkingWithContent/Types/StaticMeshes/HowTo/SettingCollision/
+- Blender Collisions: https://docs.blender.org/manual/en/latest/physics/rigid_body/properties/collisions.html
+- Mozilla Hubs ammo-shape: https://github.com/MozillaReality/hubs-blender-exporter/blob/bb28096159e1049b6b80da00b1ae1534a6ca0855/default-config.json#L608

--- a/extensions/2.0/OMI_seat/README.md
+++ b/extensions/2.0/OMI_seat/README.md
@@ -2,7 +2,7 @@
 
 ## Contributors
 
-* Aaron Franke, The Mirror Megaverse Inc.
+* Aaron Franke, Godot Engine.
 
 ## Status
 
@@ -124,6 +124,17 @@ These are the directions of the seat itself, the actual directions a character e
 * The IK position for the knees is more complicated. It needs to be adjusted by both the upper leg and lower leg offsets. For perpendicular upper and lower legs, this is trivial, you just add the vectors together. Otherwise some trigonometry is required. The knee offset can be found by adding the upper leg offset with the upper leg direction multiplied by an adjustment scalar. The adjustment scalar can be found with the lower offset length divided by the sin of the angle between the legs, minus the upper offset length divided by the tan of the angle between the legs.
 
 In a nutshell, the legs sit as close to the seat as possible while not clipping though it, therefore we offset by the leg thickness, otherwise the leg bones would be exactly on the seat's surface. We want to keep the seat's points exactly on the seat and have the character legs offset from the seat's points so that we don't play favorites for any particular leg size.
+
+### glTF Object Model
+
+The following JSON pointers are defined representing mutable properties defined by this extension, for use with the glTF Object Model including extensions such as `KHR_animation_pointer` and `KHR_interactivity`.
+
+| JSON Pointer                          | Object Model Type |
+| ------------------------------------- | ----------------- |
+| `/nodes/{}/extensions/OMI_seat/angle` | `float`           |
+| `/nodes/{}/extensions/OMI_seat/back`  | `float3`          |
+| `/nodes/{}/extensions/OMI_seat/foot`  | `float3`          |
+| `/nodes/{}/extensions/OMI_seat/knee`  | `float3`          |
 
 ### JSON Schema
 

--- a/extensions/2.0/OMI_spawn_point/README.md
+++ b/extensions/2.0/OMI_spawn_point/README.md
@@ -5,7 +5,7 @@
 * OMI glTF Extensions Group
 * Robert Long, The Matrix.org Foundation
 * Anthony Burchell, Individual Contributor
-* Aaron Franke, The Mirror Megaverse Inc.
+* Aaron Franke, Godot Engine.
 
 ## Status
 
@@ -71,6 +71,10 @@ How each application decides to use the properties, or if they are used at all, 
 * A game with no teams does not need to read or use the team property.
 * A game with teams can consider a spawn point without a team assigned as a fallback for when a player is not on a team.
 * A game with no reason to group together spawn points can ignore the group property.
+
+### glTF Object Model
+
+This extension defines no properties that can be read or manipulated by the glTF Object Model.
 
 ### JSON Schema
 


### PR DESCRIPTION
Draft because this depends on https://github.com/omigroup/gltf-extensions/pull/226 (they would otherwise conflict, so I had to choose one to go first).

This PR adds glTF Object Model property definitions for all OMI extensions, except OMI_physics_joint (pending rework) and OMI_collider (archived).

Note that this PR is not the be-all end-all of OMI's support for the glTF Object Model. It is also important that we define things like how triggers interact with interactivity, or how one might play audio or apply a force. However, this PR is the start, defining at least the properties, which will work for KHR_animation_pointer, and already have known established best practices. Also, for physics, this aligns with Eoin's Microsoft/KHR physics repo which has these already.